### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://gopi-test.visualstudio.com/4a03e223-88b4-4451-a75b-e87c8eeee25f/604b7d3d-d9c9-4cd6-933e-0827b9916932/_apis/work/boardbadge/c3e59af6-8a4e-4316-89b5-c69fc41950b5)](https://gopi-test.visualstudio.com/4a03e223-88b4-4451-a75b-e87c8eeee25f/_boards/board/t/604b7d3d-d9c9-4cd6-933e-0827b9916932/Microsoft.RequirementCategory)
 # testrepo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#29](https://gopi-test.visualstudio.com/4a03e223-88b4-4451-a75b-e87c8eeee25f/_workitems/edit/29). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.